### PR TITLE
fix: disable colorcolumn in graph window

### DIFF
--- a/lua/videre/init.lua
+++ b/lua/videre/init.lua
@@ -833,9 +833,9 @@ M.SplitView = function()
     vim.api.nvim_buf_set_option(editor_buf, 'sidescrolloff', M.config.side_scrolloff)
     vim.api.nvim_win_set_option(new_win, 'number', false)
     vim.api.nvim_win_set_option(new_win, 'relativenumber', false)
+    vim.api.nvim_win_set_option(new_win, "colorcolumn", "")
     vim.api.nvim_buf_set_option(editor_buf, "filetype", consts.plugin_name)
     vim.api.nvim_buf_set_option(editor_buf, "cursorline", false)
-    vim.api.nvim_buf_set_option(editor_buf, "colorcolumn", "")
 
     if M.config.disable_line_wrap then
         vim.api.nvim_buf_set_option(editor_buf, "wrap", false)

--- a/lua/videre/init.lua
+++ b/lua/videre/init.lua
@@ -835,6 +835,7 @@ M.SplitView = function()
     vim.api.nvim_win_set_option(new_win, 'relativenumber', false)
     vim.api.nvim_buf_set_option(editor_buf, "filetype", consts.plugin_name)
     vim.api.nvim_buf_set_option(editor_buf, "cursorline", false)
+    vim.api.nvim_buf_set_option(editor_buf, "colorcolumn", "")
 
     if M.config.disable_line_wrap then
         vim.api.nvim_buf_set_option(editor_buf, "wrap", false)


### PR DESCRIPTION
removes `:h colorcolumn`, which is misplaced in this type of buffer:
<img width="2900" height="1196" alt="Pasted image 2025-08-10 at 11 36 09@2x" src="https://github.com/user-attachments/assets/f17d7f15-0a65-40f6-a235-b85fb518aa9c" />
