### PR TITLE
fix(xml): resolve xmlhandler.tree with fallback path

### DIFF
--- a/lua/videre/langs/xml.lua
+++ b/lua/videre/langs/xml.lua
@@ -4,12 +4,21 @@ if not module_found then
     return nil
 end
 
+local tree_found, tree = pcall(require, "xmlhandler.tree")
+if not tree_found then
+    tree_found, tree = pcall(require, "xml2lua.xmlhandler.tree")
+end
+
+if not tree_found then
+    return nil
+end
+
 
 local M = {
     name = "XML",
     encode = nil,
     decode = function(xml_text)
-        local handler = require("xmlhandler.tree"):new()
+        local handler = tree:new()
         local parser = xml.parser(handler)
 
         local success, result = pcall(function(text)


### PR DESCRIPTION
XML support seems broken with the documented `a-usr/xml2lua.nvim` dependency. And `:Videre` errors out to:

```
Error parsing xml text:
...cal/share/nvim/lazy/videre.nvim/lua/videre/langs/xml.lua:12: module 'xmlhandler.tree' not found:
	no field package.preload['xmlhandler.tree']
	cache_loader: module 'xmlhandler.tree' not found
	cache_loader_lib: module 'xmlhandler.tree' not found
	no file 'lua/xmlhandler/tree.lua'
	no file 'lua/xmlhandler/tree/init.lua'
```