### PR TITLE
fix: guard add_lang against boolean return from require

### DIFF
--- a/lua/videre/langs/init.lua
+++ b/lua/videre/langs/init.lua
@@ -16,10 +16,10 @@ local M = {}
 
 ---@param lib string
 local function add_lang(lib)
-    ---@type [string[], LangSpec]|nil
-    local result = require(lib)
+    ---@type boolean, [string[], LangSpec]
+    local ok, result = pcall(require, lib)
 
-    if type(result) == "table" then
+    if ok then
         for _, lang in pairs(result[1]) do
             M[lang] = result[2]
         end

--- a/lua/videre/langs/init.lua
+++ b/lua/videre/langs/init.lua
@@ -19,7 +19,7 @@ local function add_lang(lib)
     ---@type [string[], LangSpec]|nil
     local result = require(lib)
 
-    if result ~= nil then
+    if type(result) == "table" then
         for _, lang in pairs(result[1]) do
             M[lang] = result[2]
         end

--- a/lua/videre/langs/toml.lua
+++ b/lua/videre/langs/toml.lua
@@ -2,11 +2,7 @@ local utils = require "videre.utils"
 
 local M = {}
 
-local module_found, toml = pcall(require, "toml2lua")
-
-if not module_found then
-    return nil
-end
+local toml = require "toml2lua"
 
 M[1] = { "toml" }
 

--- a/lua/videre/langs/xml.lua
+++ b/lua/videre/langs/xml.lua
@@ -1,20 +1,12 @@
-local utils = require "videre.utils"
+local utils = require("videre.utils")
 
 local M = {}
 
-local module_found, xml = pcall(require, "xml2lua")
+local xml = require("xml2lua")
 
-if not module_found then
-    return nil
-end
-
-local tree_found, tree = pcall(require, "xmlhandler.tree")
-if not tree_found then
-    tree_found, tree = pcall(require, "xml2lua.xmlhandler.tree")
-end
-
-if not tree_found then
-    return nil
+local ok, tree = pcall(require, "xmlhandler.tree")
+if not ok then
+    tree = require "xml2lua.xmlhandler.tree"
 end
 
 M[1] = { "xml" }

--- a/lua/videre/langs/yaml.lua
+++ b/lua/videre/langs/yaml.lua
@@ -2,11 +2,7 @@ local utils = require "videre.utils"
 
 local M = {}
 
-local module_found, yaml = pcall(require, "yaml_parser")
-
-if not module_found then
-    return nil
-end
+local yaml = require "yaml_parser"
 
 ---@param val VidereValue
 ---@param t VidereValueTypeName


### PR DESCRIPTION
## Problem

When an optional language module (e.g. `videre.langs.yaml`) can't load its dependency, it uses `pcall` to swallow the error and returns `nil`:

```lua
-- videre/langs/yaml.lua
local module_found, yaml = pcall(require, "yaml_parser")  -- swallows the error

if not module_found then
    return nil  -- module loads successfully, just returns nil
end
```

Per the [Lua 5.1 spec](https://www.lua.org/manual/5.1/manual.html#pdf-require), if a module loader returns a falsy value, `require` stores `true` in `package.loaded` and returns `true` — so the module's `return nil` becomes `true` at the call site. The check `if result ~= nil then` passes for booleans, so the code then tries to index `result[1]` on a boolean and crashes:

```
attempt to index local 'result' (a boolean value)
stack traceback:
  ...videre/langs/init.lua:23: in function 'add_lang'
  ...videre/langs/init.lua:30: in main chunk
```

This affects any user who has videre.nvim installed without `graph_view_yaml_parser`.

## Minimal reproduction

```lua
package.preload["optional_lang"] = function()
	return nil
end

local function add_lang(lib)
	local result = require(lib)
	print("result =", result, "type =", type(result))

	if result ~= nil then -- BUG: true passes this check
		for _, lang in pairs(result[1]) do -- crashes: attempt to index a boolean
			print(lang)
		end
	end
end

add_lang("optional_lang")
```

## Fix

Just let the `langs` modules fail when `require`d. `videre/langs/init.lua` will simply wrap the `require` call with `pcall`.
