### PR TITLE
feat: render \n, strip \r, expand \t in JSON string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,17 @@ https://github.com/user-attachments/assets/e2e6d49a-4ab8-4718-a2a2-7839ca1ba4e2
     ---@type integer
     editor_window_width = 60,
 
-    ---@comment Number of spaces a \\t escape renders as (int: [1, 16])
+    ---@comment Number of spaces each tab character expands to (int: [1,16])
     ---@type integer
     tab_width = 4,
+
+    ---@comment Toggle expansion of \t character
+    ---@type boolean
+    expand_tabs = false,
+
+    ---@comment Toggle expansion of \n and \r\n characters
+    ---@type boolean
+    expand_newlines = false,
 
     keymaps = {
         ---@comment Expand lines beyond `max_cell_lines`
@@ -234,7 +242,7 @@ https://github.com/user-attachments/assets/e2e6d49a-4ab8-4718-a2a2-7839ca1ba4e2
     ---@type integer
     scrolloff = 10,
 
-    ---@comment Set the indexing base i.e. 0, 1 or whatever else you want (int: [-999, 999])
+    ---@comment Set the indexing base i.e. 0, 1 or whatever else you want
     ---@type integer
     index_base = 0,
 }

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ https://github.com/user-attachments/assets/e2e6d49a-4ab8-4718-a2a2-7839ca1ba4e2
     ---@type integer
     editor_window_width = 60,
 
+    ---@comment Number of spaces a \\t escape renders as (int: [1, 16])
+    ---@type integer
+    tab_width = 4,
+
     keymaps = {
         ---@comment Expand lines beyond `max_cell_lines`
         ---@type string

--- a/doc/videre.txt
+++ b/doc/videre.txt
@@ -103,6 +103,7 @@ Videre accepts a configuration table. All fields are optional.
     line_style = "rounded",
 
     editor_window_width = 60,
+    tab_width = 4,
 
     keymaps = {
         expand = "E",

--- a/lua/videre/config.lua
+++ b/lua/videre/config.lua
@@ -64,6 +64,15 @@ M.config = {
     ---@comment Number of spaces each tab character expands to (int: [1,16])
     ---@type integer
     tab_width = 4,
+
+    ---@comment Toggle expansion of \t character
+    ---@type boolean
+    expand_tabs = false,
+
+    ---@comment Toggle expansion of \n and \r\n characters
+    ---@type boolean
+    expand_newlines = false,
+
     keymaps = {
         ---@comment Expand lines beyond `max_cell_lines`
         ---@type string
@@ -270,6 +279,16 @@ local function confirm_is_valid_keymap(field)
     reset_field(field)
 end
 
+---@param field string
+local function confirm_is_boolean(field)
+    local val = get_field(field)
+
+    if type(val) ~= "boolean" then
+        print_error(field .. " must be a valid keymap. Resetting to default value.")
+        reset_field(field)
+    end
+end
+
 local function validate_opts(opts, default, prefix)
     prefix = prefix or ""
 
@@ -348,6 +367,9 @@ function M.Setup(config)
     confirm_is_valid_keymap("keymaps.close_window")
 
     confirm_is_integer_in_range("index_base", -999, 999)
+
+    confirm_is_boolean("expand_tabs")
+    confirm_is_boolean("expand_newlines")
 end
 
 return M

--- a/lua/videre/config.lua
+++ b/lua/videre/config.lua
@@ -61,6 +61,9 @@ M.config = {
     ---@type integer
     editor_window_width = 60,
 
+    ---@comment Number of spaces each tab character expands to (int: [1,16])
+    ---@type integer
+    tab_width = 4,
     keymaps = {
         ---@comment Expand lines beyond `max_cell_lines`
         ---@type string
@@ -314,6 +317,7 @@ function M.Setup(config)
     confirm_is_enum("line_style", { "sharp", "rounded", "bold", "double" })
 
     confirm_is_integer_in_range("editor_window_width", 6, 999)
+    confirm_is_integer_in_range("tab_width", 1, 16)
 
     confirm_is_enum("editor_type", { "split", "floating" })
 

--- a/lua/videre/highlighting.lua
+++ b/lua/videre/highlighting.lua
@@ -1,4 +1,5 @@
 local utils = require "videre.utils"
+local config = require("videre.config").config
 
 M = {}
 
@@ -28,8 +29,9 @@ function M.HighlightFocusedCell(buf, cell, left)
     vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line, left },
         B { cell.top_render_line, left + cell.render_width })
 
-    for i, _ in ipairs(cell.values) do
-        local line = cell.top_render_line + i
+    local total_rows = cell.total_display_rows or #cell.values
+    for row = 1, total_rows do
+        local line = cell.top_render_line + row
 
         vim.hl.range(buf, ns_s, videre_special, B { line, left },
             B { line, left + 1 })
@@ -41,13 +43,13 @@ function M.HighlightFocusedCell(buf, cell, left)
             B { line, left + cell.render_width })
     end
 
-    vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line + #cell.values + 1, left },
-        B { cell.top_render_line + #cell.values + 1, left + cell.render_width })
+    vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line + total_rows + 1, left },
+        B { cell.top_render_line + total_rows + 1, left + cell.render_width })
 
     if #cell.hidden_values > 0 then
         vim.hl.range(buf, ns_s, videre_special,
-            B { cell.top_render_line + #cell.values + 2, left },
-            B { cell.top_render_line + #cell.values + 2, left + cell.render_width })
+            B { cell.top_render_line + total_rows + 2, left },
+            B { cell.top_render_line + total_rows + 2, left + cell.render_width })
     end
 
     local mouse_row = vim.api.nvim_win_get_cursor(0)[1] - 1
@@ -111,7 +113,7 @@ local function highlight_cell_values(buf, tbl, cell, left)
 
 
     for i, entry in pairs(cell.values) do
-        local line = cell.top_render_line + i
+        local line = cell.top_render_line + (entry.row_offset or i)
 
         vim.hl.range(buf, ns, "Comment",
             B { line, left + 1 },
@@ -137,8 +139,32 @@ local function highlight_cell_values(buf, tbl, cell, left)
             B { line, left + cell.render_width - entry.val_right_pad - 1 })
 
         if type == "String" then
+            local val_display = tbl.lang_spec.ValueAsString(entry[2], "string", false)
+            local val_lines = utils.DisplayLines(val_display, config.tab_width)
             local start = B({ line, left + cell.key_col_width + entry.val_left_pad + 2 })[2]
-            highlight_escapes(buf, line, tbl.lang_spec.ValueAsString(entry[2], "string", false), start)
+            highlight_escapes(buf, line, val_lines[1], start)
+
+            local val_col_width = cell.render_width - cell.key_col_width - 3
+            for li = 2, #val_lines do
+                local cont_line = line + (li - 1)
+                local cont_left_pad, _, cont_right_pad = utils.PadLine(val_lines[li], val_col_width,
+                    config.value_alignment, config.value_space)
+
+                vim.hl.range(buf, ns, "Comment",
+                    B { cont_line, left + 1 },
+                    B { cont_line, left + cell.key_col_width + 1 })
+
+                vim.hl.range(buf, ns, "Comment",
+                    B { cont_line, left + cell.key_col_width + 2 },
+                    B { cont_line, left + cell.render_width - 1 })
+
+                vim.hl.range(buf, ns, "String",
+                    B { cont_line, left + cell.key_col_width + cont_left_pad + 2 },
+                    B { cont_line, left + cell.render_width - cont_right_pad - 1 })
+
+                local cont_start = B({ cont_line, left + cell.key_col_width + cont_left_pad + 2 })[2]
+                highlight_escapes(buf, cont_line, val_lines[li], cont_start)
+            end
         end
     end
 end

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -281,6 +281,7 @@ local function render_cell_at_width(cell, tbl, width, is_root)
     string.rep(boxes.HorizontalBox(), width - key_col_width - 3) ..
     boxes.TopRight() }
 
+    local row_offset = 1
     for i, entry in ipairs(cell.values) do
         local key, val = entry[1], entry[2]
         local val_type = utils.ValueType(val)
@@ -310,6 +311,7 @@ local function render_cell_at_width(cell, tbl, width, is_root)
 
         entry.val_left_pad, entry.val_right_pad = val_left_pad, val_right_pad
         entry.key_left_pad, entry.key_right_pad = key_left_pad, key_right_pad
+        entry.row_offset = row_offset
 
         rows[#rows + 1] = left .. key_string ..
             boxes.VerticalBox() ..
@@ -321,7 +323,10 @@ local function render_cell_at_width(cell, tbl, width, is_root)
                 config.value_alignment, config.value_space)
             rows[#rows + 1] = boxes.VerticalBox() .. blank_key .. boxes.VerticalBox() .. cont_string .. vert
         end
+
+        row_offset = row_offset + #val_lines
     end
+    cell.total_display_rows = row_offset - 1
 
     if #cell.hidden_values > 0 then
         rows[#rows + 1] = boxes.BoxCollapse() ..
@@ -440,13 +445,11 @@ local function aggregate_connection_objects_for_layer(layer, tbl)
 
     for _, cell in ipairs(layer.cells) do
         if not cell.is_hidden then
-            local line_offset = 0
             for _, entry in ipairs(cell.values) do
                 local val = entry[2]
-                line_offset = line_offset + 1
                 local value_type = utils.ValueType(val)
                 if value_type == "array" or value_type == "object" then
-                    val.from_render_line = cell.top_render_line + line_offset
+                    val.from_render_line = cell.top_render_line + (entry.row_offset or 0)
                     val.to_render_line = tbl.layers[val.layer].cells[val.cell].top_render_line
 
                     ---@type boolean|nil
@@ -590,12 +593,13 @@ function M.JumpToCellAndValue(tbl, layer_num, cell_num, val)
 
     local jump = true
     if val == "expand" then
-        row = row + config.max_cell_lines + 2
+        row = row + (cell.total_display_rows or config.max_cell_lines) + 2
     elseif val ~= nil and val > #cell.values then
-        row = row + #cell.values + 2
+        row = row + (cell.total_display_rows or #cell.values) + 2
         jump = false
     elseif val ~= nil then
-        row = row + val + 1
+        local entry = cell.values[val]
+        row = row + (entry and entry.row_offset or val) + 1
     else
         row = row + 2
     end

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -141,12 +141,26 @@ function M.DataToVidereTable(data, from_buffer, is_saved, lang_spec)
     return tbl
 end
 
+---@param str string
+---@return string[]
+local function display_lines(str)
+    str = str:gsub("\\r", "")
+    str = str:gsub("\\t", string.rep(" ", config.tab_width))
+    return vim.split(str, "\\n", { plain = true })
+end
+
 ---@param val VidereValue
 ---@param tbl VidereTable
 ---@param is_key boolean
 ---@return integer
 local function get_value_width(val, tbl, is_key)
-    return utils.StringWidth(tbl.lang_spec.ValueAsString(val, utils.ValueType(val), is_key));
+    local str = tbl.lang_spec.ValueAsString(val, utils.ValueType(val), is_key)
+    local max_w = 0
+    for _, line in ipairs(display_lines(str)) do
+        local w = utils.StringWidth(line)
+        if w > max_w then max_w = w end
+    end
+    return max_w
 end
 
 ---@param cell VidereCell
@@ -204,14 +218,22 @@ local function get_layer_min_width(layer, tbl)
 end
 
 ---@param layer VidereLayer
+---@param tbl VidereTable
 ---@return integer
-local function get_layer_min_height(layer)
+local function get_layer_min_height(layer, tbl)
     local layer_height = 0
     for _, cell in pairs(layer.cells) do
         local cell_height = 0
         if not cell.is_hidden then
-            for _ in ipairs(cell.values) do
-                cell_height = cell_height + 1
+            for _, entry in ipairs(cell.values) do
+                local val = entry[2]
+                local val_type = utils.ValueType(val)
+                if val_type == "string" then
+                    local str = tbl.lang_spec.ValueAsString(val, val_type, false)
+                    cell_height = cell_height + #display_lines(str)
+                else
+                    cell_height = cell_height + 1
+                end
             end
 
             cell_height = cell_height + 2
@@ -236,7 +258,7 @@ end
 local function get_table_min_height(tbl)
     local min_height = 0
     for _, layer in pairs(tbl.layers) do
-        local layer_height = get_layer_min_height(layer)
+        local layer_height = get_layer_min_height(layer, tbl)
         if min_height < layer_height then
             min_height = layer_height
         end
@@ -279,8 +301,12 @@ local function render_cell_at_width(cell, tbl, width, is_root)
         local key_left_pad, key_string, key_right_pad = utils.ValueAsString(tbl, key, key_col_width, config
             .key_alignment, config.key_space, true)
 
-        local val_left_pad, value_string, val_right_pad = utils.ValueAsString(tbl, val, width - key_col_width - 3,
-            config.value_alignment, config.value_space, false)
+        local val_col_width = width - key_col_width - 3
+        local val_display = tbl.lang_spec.ValueAsString(val, val_type, false)
+        local val_lines = display_lines(val_display)
+
+        local val_left_pad, value_string, val_right_pad = utils.PadLine(val_lines[1], val_col_width,
+            config.value_alignment, config.value_space)
 
         entry.val_left_pad, entry.val_right_pad = val_left_pad, val_right_pad
         entry.key_left_pad, entry.key_right_pad = key_left_pad, key_right_pad
@@ -288,6 +314,13 @@ local function render_cell_at_width(cell, tbl, width, is_root)
         rows[#rows + 1] = left .. key_string ..
             boxes.VerticalBox() ..
             value_string .. vert
+
+        local blank_key = string.rep(config.key_space, key_col_width)
+        for li = 2, #val_lines do
+            local _, cont_string, _ = utils.PadLine(val_lines[li], val_col_width,
+                config.value_alignment, config.value_space)
+            rows[#rows + 1] = boxes.VerticalBox() .. blank_key .. boxes.VerticalBox() .. cont_string .. vert
+        end
     end
 
     if #cell.hidden_values > 0 then

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -141,13 +141,6 @@ function M.DataToVidereTable(data, from_buffer, is_saved, lang_spec)
     return tbl
 end
 
----@param str string
----@return string[]
-local function display_lines(str)
-    str = str:gsub("\\r", "")
-    str = str:gsub("\\t", string.rep(" ", config.tab_width))
-    return vim.split(str, "\\n", { plain = true })
-end
 
 ---@param val VidereValue
 ---@param tbl VidereTable
@@ -155,8 +148,11 @@ end
 ---@return integer
 local function get_value_width(val, tbl, is_key)
     local str = tbl.lang_spec.ValueAsString(val, utils.ValueType(val), is_key)
+    if is_key then
+        return utils.StringWidth(str)
+    end
     local max_w = 0
-    for _, line in ipairs(display_lines(str)) do
+    for _, line in ipairs(utils.DisplayLines(str, config.tab_width)) do
         local w = utils.StringWidth(line)
         if w > max_w then max_w = w end
     end
@@ -230,7 +226,7 @@ local function get_layer_min_height(layer, tbl)
                 local val_type = utils.ValueType(val)
                 if val_type == "string" then
                     local str = tbl.lang_spec.ValueAsString(val, val_type, false)
-                    cell_height = cell_height + #display_lines(str)
+                    cell_height = cell_height + #utils.DisplayLines(str, config.tab_width)
                 else
                     cell_height = cell_height + 1
                 end
@@ -304,7 +300,7 @@ local function render_cell_at_width(cell, tbl, width, is_root)
 
         local val_col_width = width - key_col_width - 3
         local val_display = tbl.lang_spec.ValueAsString(val, val_type, false)
-        local val_lines = display_lines(val_display)
+        local val_lines = utils.DisplayLines(val_display, config.tab_width)
 
         local val_left_pad, value_string, val_right_pad = utils.PadLine(val_lines[1], val_col_width,
             config.value_alignment, config.value_space)

--- a/lua/videre/table_th.lua
+++ b/lua/videre/table_th.lua
@@ -28,14 +28,16 @@
 ---@field data DataObj
 ---@field data_ref DataObjectRef
 ---@field key_col_width integer|nil
+---@field total_display_rows integer|nil
 
 ---@class VidereEntry
 ---@field [1] integer|string
----@field [2] VidereValue 
+---@field [2] VidereValue
 ---@field val_left_pad integer|nil
 ---@field key_left_pad integer|nil
 ---@field val_right_pad integer|nil
 ---@field key_right_pad integer|nil
+---@field row_offset integer|nil
 
 ---@alias CellValRef [integer, integer, integer]
 

--- a/lua/videre/utils.lua
+++ b/lua/videre/utils.lua
@@ -100,9 +100,13 @@ end
 ---  \\   → append "\\\\" to current_line (escaped backslash; next char skipped)
 ---  \\X  → append both chars unchanged to current_line
 ---@param str string
----@param tab_width integer
 ---@return string[]
-function M.DisplayLines(str, tab_width)
+function M.DisplayLines(str)
+    local config = require("videre.config").config
+    local tab_width = config.tab_width
+    local expand_tabs = config.expand_tabs
+    local expand_newlines = config.expand_newlines
+
     local lines = {}
     local current_line = {}
     local str_idx = 1
@@ -113,11 +117,11 @@ function M.DisplayLines(str, tab_width)
             if next == [[\]] then
                 current_line[#current_line + 1] = [[\\]]
                 str_idx = str_idx + 2
-            elseif next == "n" then
+            elseif next == "n" and expand_newlines then
                 lines[#lines + 1] = table.concat(current_line)
                 current_line = {}
                 str_idx = str_idx + 2
-            elseif next == "r" then
+            elseif next == "r" and expand_newlines then
                 if str:sub(str_idx + 2, str_idx + 3) == [[\n]] then
                     lines[#lines + 1] = table.concat(current_line)
                     current_line = {}
@@ -126,7 +130,7 @@ function M.DisplayLines(str, tab_width)
                     current_line[#current_line + 1] = c .. next
                     str_idx = str_idx + 2
                 end
-            elseif next == "t" then
+            elseif next == "t" and expand_tabs then
                 current_line[#current_line + 1] = string.rep(" ", tab_width)
                 str_idx = str_idx + 2
             else

--- a/lua/videre/utils.lua
+++ b/lua/videre/utils.lua
@@ -68,19 +68,14 @@ function M.NumberWidth(val)
     return #tostring(val)
 end
 
----@param tbl VidereTable
----@param val VidereValue
+---@param str string
 ---@param width integer
 ---@param align RowAlignment
 ---@param space string
----@param is_key boolean
 ---@return integer, string, integer
-function M.ValueAsString(tbl, val, width, align, space, is_key)
-    local t = M.ValueType(val)
-    local str = tbl.lang_spec.ValueAsString(val, t, is_key)
-
+function M.PadLine(str, width, align, space)
     local current_width = M.StringWidth(str)
-    local pad = width - current_width
+    local pad = math.max(0, width - current_width)
 
     if align == "left" then
         return 0, str .. string.rep(space, pad), pad
@@ -91,6 +86,20 @@ function M.ValueAsString(tbl, val, width, align, space, is_key)
         local right = pad - left
         return left, string.rep(space, left) .. str .. string.rep(space, right), right
     end
+end
+
+---@param tbl VidereTable
+---@param val VidereValue
+---@param width integer
+---@param align RowAlignment
+---@param space string
+---@param is_key boolean
+---@return integer, string, integer
+function M.ValueAsString(tbl, val, width, align, space, is_key)
+    local t = M.ValueType(val)
+    local str = tbl.lang_spec.ValueAsString(val, t, is_key)
+    local first_line = vim.split(str, "\\n", { plain = true })[1]
+    return M.PadLine(first_line, width, align, space)
 end
 
 ---@param statusline_offset integer

--- a/lua/videre/utils.lua
+++ b/lua/videre/utils.lua
@@ -88,6 +88,60 @@ function M.PadLine(str, width, align, space)
     end
 end
 
+---Split a ValueAsString display string into visual rows.
+---Walks str one character at a time via str_idx. On a backslash, the next
+---character is consumed as a pair into current_line so that an escaped
+---backslash (\\) never causes the character after it to be misread as a
+---\\n/\\r/\\t marker. Completed rows are flushed into lines[]:
+---  \\n  → flush current_line into lines, reset current_line
+---  \\r\\n → treated as a single newline split (consume all 4 chars)
+---  \\r  → keep literal \r in current_line (standalone CR, e.g. old Mac endings or regex patterns)
+---  \\t  → append tab_width spaces to current_line
+---  \\   → append "\\\\" to current_line (escaped backslash; next char skipped)
+---  \\X  → append both chars unchanged to current_line
+---@param str string
+---@param tab_width integer
+---@return string[]
+function M.DisplayLines(str, tab_width)
+    local lines = {}
+    local current_line = {}
+    local str_idx = 1
+    while str_idx <= #str do
+        local c = str:sub(str_idx, str_idx)
+        if c == [[\]] then
+            local next = str:sub(str_idx + 1, str_idx + 1)
+            if next == [[\]] then
+                current_line[#current_line + 1] = [[\\]]
+                str_idx = str_idx + 2
+            elseif next == "n" then
+                lines[#lines + 1] = table.concat(current_line)
+                current_line = {}
+                str_idx = str_idx + 2
+            elseif next == "r" then
+                if str:sub(str_idx + 2, str_idx + 3) == [[\n]] then
+                    lines[#lines + 1] = table.concat(current_line)
+                    current_line = {}
+                    str_idx = str_idx + 4
+                else
+                    current_line[#current_line + 1] = c .. next
+                    str_idx = str_idx + 2
+                end
+            elseif next == "t" then
+                current_line[#current_line + 1] = string.rep(" ", tab_width)
+                str_idx = str_idx + 2
+            else
+                current_line[#current_line + 1] = c .. next
+                str_idx = str_idx + 2
+            end
+        else
+            current_line[#current_line + 1] = c
+            str_idx = str_idx + 1
+        end
+    end
+    lines[#lines + 1] = table.concat(current_line)
+    return lines
+end
+
 ---@param tbl VidereTable
 ---@param val VidereValue
 ---@param width integer
@@ -98,7 +152,11 @@ end
 function M.ValueAsString(tbl, val, width, align, space, is_key)
     local t = M.ValueType(val)
     local str = tbl.lang_spec.ValueAsString(val, t, is_key)
-    local first_line = vim.split(str, "\\n", { plain = true })[1]
+    if is_key then
+        return M.PadLine(str, width, align, space)
+    end
+    local tab_width = require("videre.config").config.tab_width
+    local first_line = M.DisplayLines(str, tab_width)[1]
     return M.PadLine(first_line, width, align, space)
 end
 

--- a/lua/videre/utils.lua
+++ b/lua/videre/utils.lua
@@ -150,12 +150,37 @@ function M.GetHoveredCell(tbl)
     local cell = layer.cells[cell_in]
 
     ---@type integer|nil|"expand"
-    local value_on = mrow - cell.top_render_line
+    local raw_offset = mrow - cell.top_render_line
+    local value_on
 
-    if value_on == #cell.values + 1 and #cell.hidden_values > 0 then
-        value_on = "expand"
-    elseif value_on > #cell.values or value_on == 0 then
+    if raw_offset == 0 then
         value_on = nil
+    else
+        local found = nil
+        for j, entry in ipairs(cell.values) do
+            if entry.row_offset then
+                local next_offset = (cell.values[j + 1] and cell.values[j + 1].row_offset)
+                    or ((cell.total_display_rows or #cell.values) + 1)
+                if raw_offset >= entry.row_offset and raw_offset < next_offset then
+                    found = j
+                    break
+                end
+            else
+                -- fallback: original single-row-per-value assumption
+                if raw_offset == j then
+                    found = j
+                    break
+                end
+            end
+        end
+
+        if found then
+            value_on = found
+        elseif raw_offset == (cell.total_display_rows or #cell.values) + 1 and #cell.hidden_values > 0 then
+            value_on = "expand"
+        else
+            value_on = nil
+        end
     end
 
     return layer_in, cell_in, value_on


### PR DESCRIPTION
## Summary

- **`\n`** — rendered as actual newlines; each line occupies its own row in the cell
- **`\r`** — stripped silently (avoids trailing `\r` artifacts from `\r\n` line endings common in API responses)
- **`\t`** — expanded to spaces; width controlled by the new `tab_width` config option (default `4`, range `1–16`)

## Implementation

`val_as_string` in `langs/json.lua` now escapes all control characters except `\n` (not escaped) and `\r` (stripped). Tab characters are replaced with `string.rep(" ", config.tab_width)`.

To support multi-row rendering, three functions in `table.lua` were updated to split display strings on `\n`:
- `get_value_width` — uses max line width instead of full string width
- `get_layer_min_height` — counts actual display lines for string values
- `render_cell_at_width` — emits continuation rows (blank key column) for each line beyond the first

For highlighting in `highlighting.lua`:
`highlight_cell_values` — highlights the actual cell

`utils.lua` gains a `PadLine` helper extracted from `ValueAsString`, used directly for continuation row padding.

## Results

<img width="1864" height="893" alt="image" src="https://github.com/user-attachments/assets/dde02f7e-08bf-48f6-9a17-a7ee502bd81f" />


## Test plan

- [x] Open a JSON file with `\n` in string values; confirm each line renders as a separate row
- [x] Open a JSON file with `\r\n` line endings; confirm no trailing `\r` visible
- [x] Open a JSON file with `\t` in string values; confirm tabs render as spaces
- [x] Set `tab_width = 2` in setup; confirm tab expansion width changes
- [x] Confirm non-string values (numbers, booleans, null, objects, arrays) render unchanged
- [x] Update highlighting functions
