### PR TITLE
fix: set nowait on close_window keymap

### DIFF
--- a/lua/videre/actions.lua
+++ b/lua/videre/actions.lua
@@ -396,7 +396,7 @@ function M.MakeCloseWindowMapping(buf, videre_table)
                 end
             })
         end
-    end, { buf = buf })
+    end, { buf = buf, nowait = true })
 end
 
 ---@param buf integer


### PR DESCRIPTION
## Summary

I have global keymaps that begin with `q` (eg, `qd`) and they cause the `q` keymap for closing the videre window to wait `timeoutlen`. This PR makes sure that the `q` keymap does not wait for longer keymaps and fires immediately.

- Adds `nowait = true` to the `close_window` keymap in `MakeCloseWindowMapping`

Since `q` is re-registered on every `CursorMoved`, the fix should be a part of the plugin rather than a customization in the user's config.

This fix can (should?) be extended to all plugin keymaps, not just the one for closing the window.

This is a redo of the #10 fix.