### PR TITLE
feat: add max_line_width option to wrap long string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ https://github.com/user-attachments/assets/e2e6d49a-4ab8-4718-a2a2-7839ca1ba4e2
     ---@type boolean
     expand_newlines = false,
 
+    ---@comment Max display width of string values in characters; 0 disables wrapping (int: [0, 9999])
+    ---@type integer
+    max_line_width = 0,
     keymaps = {
         ---@comment Expand lines beyond `max_cell_lines`
         ---@type string

--- a/doc/videre.txt
+++ b/doc/videre.txt
@@ -104,6 +104,7 @@ Videre accepts a configuration table. All fields are optional.
 
     editor_window_width = 60,
     tab_width = 4,
+    max_line_width = 0,  -- wrap string values at this many chars; 0 disables (int: [0, 9999])
 
     keymaps = {
         expand = "E",

--- a/lua/videre/config.lua
+++ b/lua/videre/config.lua
@@ -73,6 +73,9 @@ M.config = {
     ---@type boolean
     expand_newlines = false,
 
+    ---@comment Max display width of string values in characters; 0 disables wrapping (int: [0,9999])
+    ---@type integer
+    max_line_width = 0,
     keymaps = {
         ---@comment Expand lines beyond `max_cell_lines`
         ---@type string
@@ -345,6 +348,7 @@ function M.Setup(config)
 
     confirm_is_integer_in_range("editor_window_width", 6, 999)
     confirm_is_integer_in_range("tab_width", 1, 16)
+    confirm_is_integer_in_range("max_line_width", 0, 9999)
 
     confirm_is_enum("editor_type", { "split", "floating" })
 

--- a/lua/videre/config.lua
+++ b/lua/videre/config.lua
@@ -75,7 +75,8 @@ M.config = {
 
     ---@comment Max display width of string values in characters; 0 disables wrapping (int: [0,9999])
     ---@type integer
-    max_line_width = 0,
+    max_line_width = 30,
+
     keymaps = {
         ---@comment Expand lines beyond `max_cell_lines`
         ---@type string

--- a/lua/videre/highlighting.lua
+++ b/lua/videre/highlighting.lua
@@ -3,6 +3,10 @@ local config = require("videre.config").config
 
 M = {}
 
+-- Wraps by Unicode codepoint count (strchars), not display width or grapheme clusters;
+-- combining characters and ZWJ sequences may be split across rows.
+-- When expand_newlines=false, a \X escape pair that straddles a wrap boundary will
+-- lose its SpecialChar highlight on both halves (cosmetic only, display is unaffected).
 local function wrap_and_split(str)
     local max_w = config.max_line_width
     if max_w <= 0 then

--- a/lua/videre/highlighting.lua
+++ b/lua/videre/highlighting.lua
@@ -6,10 +6,10 @@ M = {}
 local function wrap_and_split(str)
     local max_w = config.max_line_width
     if max_w <= 0 then
-        return vim.split(str, "\n", { plain = true })
+        return utils.DisplayLines(str)
     end
     local result = {}
-    for _, seg_line in ipairs(vim.split(str, "\n", { plain = true })) do
+    for _, seg_line in ipairs(utils.DisplayLines(str)) do
         local char_len = vim.fn.strchars(seg_line)
         if char_len <= max_w then
             result[#result + 1] = seg_line

--- a/lua/videre/highlighting.lua
+++ b/lua/videre/highlighting.lua
@@ -3,31 +3,6 @@ local config = require("videre.config").config
 
 M = {}
 
--- Wraps by Unicode codepoint count (strchars), not display width or grapheme clusters;
--- combining characters and ZWJ sequences may be split across rows.
--- When expand_newlines=false, a \X escape pair that straddles a wrap boundary will
--- lose its SpecialChar highlight on both halves (cosmetic only, display is unaffected).
-local function wrap_and_split(str)
-    local max_w = config.max_line_width
-    if max_w <= 0 then
-        return utils.DisplayLines(str)
-    end
-    local result = {}
-    for _, seg_line in ipairs(utils.DisplayLines(str)) do
-        local char_len = vim.fn.strchars(seg_line)
-        if char_len <= max_w then
-            result[#result + 1] = seg_line
-        else
-            local pos = 0
-            while pos < char_len do
-                result[#result + 1] = vim.fn.strcharpart(seg_line, pos, max_w)
-                pos = pos + max_w
-            end
-        end
-    end
-    return result
-end
-
 local videre_special = "Special"
 local ns = vim.api.nvim_create_namespace("VidereBase")
 local ns_s = vim.api.nvim_create_namespace("VidereStatus")
@@ -179,7 +154,7 @@ local function highlight_cell_values(buf, tbl, cell, left)
 
         if type == "String" then
             local full_str = tbl.lang_spec.ValueAsString(entry[2], "string", false)
-            local segments = wrap_and_split(full_str)
+            local segments = utils.DisplayLines(full_str)
             local val_col_width = cell.render_width - cell.key_col_width - 3
             for si, seg in ipairs(segments) do
                 local seg_line = line + (si - 1)

--- a/lua/videre/highlighting.lua
+++ b/lua/videre/highlighting.lua
@@ -3,9 +3,38 @@ local config = require("videre.config").config
 
 M = {}
 
+local function wrap_and_split(str)
+    local max_w = config.max_line_width
+    if max_w <= 0 then
+        return vim.split(str, "\n", { plain = true })
+    end
+    local result = {}
+    for _, seg_line in ipairs(vim.split(str, "\n", { plain = true })) do
+        local char_len = vim.fn.strchars(seg_line)
+        if char_len <= max_w then
+            result[#result + 1] = seg_line
+        else
+            local pos = 0
+            while pos < char_len do
+                result[#result + 1] = vim.fn.strcharpart(seg_line, pos, max_w)
+                pos = pos + max_w
+            end
+        end
+    end
+    return result
+end
+
 local videre_special = "Special"
 local ns = vim.api.nvim_create_namespace("VidereBase")
 local ns_s = vim.api.nvim_create_namespace("VidereStatus")
+
+local function entry_row_span(cell, i, total_rows)
+    local entry = cell.values[i]
+    local next_entry = cell.values[i + 1]
+    local base = entry.row_offset or i
+    local next_base = next_entry and (next_entry.row_offset or (i + 1)) or (total_rows + 1)
+    return next_base - base
+end
 
 ---@param pos [integer, integer]
 ---@param buf integer
@@ -30,17 +59,21 @@ function M.HighlightFocusedCell(buf, cell, left)
         B { cell.top_render_line, left + cell.render_width })
 
     local total_rows = cell.total_display_rows or #cell.values
-    for row = 1, total_rows do
-        local line = cell.top_render_line + row
+    for i, entry in ipairs(cell.values) do
+        local first_line = cell.top_render_line + (entry.row_offset or i)
+        local span = entry_row_span(cell, i, total_rows)
 
-        vim.hl.range(buf, ns_s, videre_special, B { line, left },
-            B { line, left + 1 })
+        for s = 0, span - 1 do
+            local line = first_line + s
+            vim.hl.range(buf, ns_s, videre_special, B { line, left },
+                B { line, left + 1 })
 
-        vim.hl.range(buf, ns_s, videre_special, B { line, left + cell.key_col_width + 1 },
-            B { line, left + cell.key_col_width + 2 })
+            vim.hl.range(buf, ns_s, videre_special, B { line, left + cell.key_col_width + 1 },
+                B { line, left + cell.key_col_width + 2 })
 
-        vim.hl.range(buf, ns_s, videre_special, B { line, left + cell.render_width - 1 },
-            B { line, left + cell.render_width })
+            vim.hl.range(buf, ns_s, videre_special, B { line, left + cell.render_width - 1 },
+                B { line, left + cell.render_width })
+        end
     end
 
     vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line + total_rows + 1, left },
@@ -112,8 +145,10 @@ local function highlight_cell_values(buf, tbl, cell, left)
     end
 
 
+    local total_rows = cell.total_display_rows or #cell.values
     for i, entry in pairs(cell.values) do
         local line = cell.top_render_line + (entry.row_offset or i)
+        local span = entry_row_span(cell, i, total_rows)
 
         vim.hl.range(buf, ns, "Comment",
             B { line, left + 1 },
@@ -139,31 +174,35 @@ local function highlight_cell_values(buf, tbl, cell, left)
             B { line, left + cell.render_width - entry.val_right_pad - 1 })
 
         if type == "String" then
-            local val_display = tbl.lang_spec.ValueAsString(entry[2], "string", false)
-            local val_lines = utils.DisplayLines(val_display, config.tab_width)
-            local start = B({ line, left + cell.key_col_width + entry.val_left_pad + 2 })[2]
-            highlight_escapes(buf, line, val_lines[1], start)
-
+            local full_str = tbl.lang_spec.ValueAsString(entry[2], "string", false)
+            local segments = wrap_and_split(full_str)
             local val_col_width = cell.render_width - cell.key_col_width - 3
-            for li = 2, #val_lines do
-                local cont_line = line + (li - 1)
-                local cont_left_pad, _, cont_right_pad = utils.PadLine(val_lines[li], val_col_width,
-                    config.value_alignment, config.value_space)
-
-                vim.hl.range(buf, ns, "Comment",
-                    B { cont_line, left + 1 },
-                    B { cont_line, left + cell.key_col_width + 1 })
-
-                vim.hl.range(buf, ns, "Comment",
-                    B { cont_line, left + cell.key_col_width + 2 },
-                    B { cont_line, left + cell.render_width - 1 })
-
-                vim.hl.range(buf, ns, "String",
-                    B { cont_line, left + cell.key_col_width + cont_left_pad + 2 },
-                    B { cont_line, left + cell.render_width - cont_right_pad - 1 })
-
-                local cont_start = B({ cont_line, left + cell.key_col_width + cont_left_pad + 2 })[2]
-                highlight_escapes(buf, cont_line, val_lines[li], cont_start)
+            for si, seg in ipairs(segments) do
+                local seg_line = line + (si - 1)
+                local seg_pad, seg_rpad
+                if si == 1 then
+                    seg_pad = entry.val_left_pad
+                    seg_rpad = entry.val_right_pad
+                else
+                    seg_pad, _, seg_rpad = utils.PadLine(seg, val_col_width, config.value_alignment, config.value_space)
+                    vim.hl.range(buf, ns, "Comment", B { seg_line, left + 1 },
+                        B { seg_line, left + cell.key_col_width + 1 })
+                    vim.hl.range(buf, ns, "Comment", B { seg_line, left + cell.key_col_width + 2 },
+                        B { seg_line, left + cell.render_width - 1 })
+                    vim.hl.range(buf, ns, "String",
+                        B { seg_line, left + cell.key_col_width + seg_pad + 2 },
+                        B { seg_line, left + cell.render_width - seg_rpad - 1 })
+                end
+                local seg_start = B({ seg_line, left + cell.key_col_width + seg_pad + 2 })[2]
+                highlight_escapes(buf, seg_line, seg, seg_start)
+            end
+        else
+            for s = 1, span - 1 do
+                local cont = line + s
+                vim.hl.range(buf, ns, "Comment", B { cont, left + cell.key_col_width + 2 },
+                    B { cont, left + cell.render_width - 1 })
+                vim.hl.range(buf, ns, type, B { cont, left + cell.key_col_width + 2 },
+                    B { cont, left + cell.render_width - 1 })
             end
         end
     end

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -145,33 +145,6 @@ function M.DataToVidereTable(data, from_buffer, is_saved, lang_spec, states, sta
     return tbl
 end
 
-
----@param str string
----@return string[]
--- Wraps by Unicode codepoint count (strchars), not display width or grapheme clusters;
--- combining characters and ZWJ sequences may be split across rows.
--- When expand_newlines=false, a \X escape pair that straddles a wrap boundary will
--- lose its SpecialChar highlight on both halves (cosmetic only, display is unaffected).
-local function wrap_and_split(str)
-    local lines = utils.DisplayLines(str)
-    local max_w = config.max_line_width
-    if max_w <= 0 then return lines end
-    local result = {}
-    for _, line in ipairs(lines) do
-        local char_len = vim.fn.strchars(line)
-        if char_len <= max_w then
-            result[#result + 1] = line
-        else
-            local pos = 0
-            while pos < char_len do
-                result[#result + 1] = vim.fn.strcharpart(line, pos, max_w)
-                pos = pos + max_w
-            end
-        end
-    end
-    return result
-end
-
 ---@param val VidereValue
 ---@param tbl VidereTable
 ---@param is_key boolean
@@ -183,7 +156,7 @@ local function get_value_width(val, tbl, is_key)
         return utils.StringWidth(str)
     end
     local max_w = 0
-    for _, line in ipairs(wrap_and_split(str)) do
+    for _, line in ipairs(utils.DisplayLines(str)) do
         local w = utils.StringWidth(line)
         if w > max_w then max_w = w end
     end
@@ -257,7 +230,7 @@ local function get_layer_min_height(layer, tbl)
                 local val_type = utils.ValueType(val)
                 if val_type == "string" then
                     local str = tbl.lang_spec.ValueAsString(val, val_type, false)
-                    cell_height = cell_height + #wrap_and_split(str)
+                    cell_height = cell_height + #utils.DisplayLines(str)
                 else
                     cell_height = cell_height + 1
                 end
@@ -308,7 +281,6 @@ local function render_cell_at_width(cell, tbl, width, is_root)
     string.rep(boxes.HorizontalBox(), width - key_col_width - 3) ..
     boxes.TopRight() }
 
-    local row_offset = 1
     for i, entry in ipairs(cell.values) do
         local key, val = entry[1], entry[2]
         local val_type = utils.ValueType(val)
@@ -331,7 +303,7 @@ local function render_cell_at_width(cell, tbl, width, is_root)
 
         local val_col_width = width - key_col_width - 3
         local val_display = tbl.lang_spec.ValueAsString(val, val_type, false)
-        local val_lines = val_type == "string" and wrap_and_split(val_display)
+        local val_lines = val_type == "string" and utils.DisplayLines(val_display)
             or { val_display }
 
         local val_left_pad, value_string, val_right_pad = utils.PadLine(val_lines[1], val_col_width,

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -149,7 +149,7 @@ end
 ---@param str string
 ---@return string[]
 local function wrap_and_split(str)
-    local lines = vim.split(str, "\n", { plain = true })
+    local lines = utils.DisplayLines(str)
     local max_w = config.max_line_width
     if max_w <= 0 then return lines end
     local result = {}

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -146,17 +146,40 @@ function M.DataToVidereTable(data, from_buffer, is_saved, lang_spec, states, sta
 end
 
 
+---@param str string
+---@return string[]
+local function wrap_and_split(str)
+    local lines = vim.split(str, "\n", { plain = true })
+    local max_w = config.max_line_width
+    if max_w <= 0 then return lines end
+    local result = {}
+    for _, line in ipairs(lines) do
+        local char_len = vim.fn.strchars(line)
+        if char_len <= max_w then
+            result[#result + 1] = line
+        else
+            local pos = 0
+            while pos < char_len do
+                result[#result + 1] = vim.fn.strcharpart(line, pos, max_w)
+                pos = pos + max_w
+            end
+        end
+    end
+    return result
+end
+
 ---@param val VidereValue
 ---@param tbl VidereTable
 ---@param is_key boolean
 ---@return integer
 local function get_value_width(val, tbl, is_key)
-    local str = tbl.lang_spec.ValueAsString(val, utils.ValueType(val), is_key)
-    if is_key then
+    local val_type = utils.ValueType(val)
+    local str = tbl.lang_spec.ValueAsString(val, val_type, is_key)
+    if is_key or val_type ~= "string" then
         return utils.StringWidth(str)
     end
     local max_w = 0
-    for _, line in ipairs(utils.DisplayLines(str, config.tab_width)) do
+    for _, line in ipairs(wrap_and_split(str)) do
         local w = utils.StringWidth(line)
         if w > max_w then max_w = w end
     end
@@ -230,7 +253,7 @@ local function get_layer_min_height(layer, tbl)
                 local val_type = utils.ValueType(val)
                 if val_type == "string" then
                     local str = tbl.lang_spec.ValueAsString(val, val_type, false)
-                    cell_height = cell_height + #utils.DisplayLines(str, config.tab_width)
+                    cell_height = cell_height + #wrap_and_split(str)
                 else
                     cell_height = cell_height + 1
                 end
@@ -304,14 +327,15 @@ local function render_cell_at_width(cell, tbl, width, is_root)
 
         local val_col_width = width - key_col_width - 3
         local val_display = tbl.lang_spec.ValueAsString(val, val_type, false)
-        local val_lines = utils.DisplayLines(val_display, config.tab_width)
+        local val_lines = val_type == "string" and wrap_and_split(val_display)
+            or { val_display }
 
         local val_left_pad, value_string, val_right_pad = utils.PadLine(val_lines[1], val_col_width,
             config.value_alignment, config.value_space)
 
         entry.val_left_pad, entry.val_right_pad = val_left_pad, val_right_pad
         entry.key_left_pad, entry.key_right_pad = key_left_pad, key_right_pad
-        entry.row_offset = row_offset
+        entry.row_offset = #rows
 
         rows[#rows + 1] = left .. key_string ..
             boxes.VerticalBox() ..
@@ -323,10 +347,8 @@ local function render_cell_at_width(cell, tbl, width, is_root)
                 config.value_alignment, config.value_space)
             rows[#rows + 1] = boxes.VerticalBox() .. blank_key .. boxes.VerticalBox() .. cont_string .. vert
         end
-
-        row_offset = row_offset + #val_lines
     end
-    cell.total_display_rows = row_offset - 1
+    cell.total_display_rows = #rows - 1
 
     if #cell.hidden_values > 0 then
         rows[#rows + 1] = boxes.BoxCollapse() ..
@@ -445,11 +467,11 @@ local function aggregate_connection_objects_for_layer(layer, tbl)
 
     for _, cell in ipairs(layer.cells) do
         if not cell.is_hidden then
-            for _, entry in ipairs(cell.values) do
+            for i, entry in ipairs(cell.values) do
                 local val = entry[2]
                 local value_type = utils.ValueType(val)
                 if value_type == "array" or value_type == "object" then
-                    val.from_render_line = cell.top_render_line + (entry.row_offset or 0)
+                    val.from_render_line = cell.top_render_line + (entry.row_offset or i)
                     val.to_render_line = tbl.layers[val.layer].cells[val.cell].top_render_line
 
                     ---@type boolean|nil
@@ -591,11 +613,12 @@ function M.JumpToCellAndValue(tbl, layer_num, cell_num, val)
     local cell = layer.cells[cell_num]
     local row = cell.top_render_line
 
+    local total_display_rows = cell.total_display_rows or #cell.values
     local jump = true
     if val == "expand" then
         row = row + (cell.total_display_rows or config.max_cell_lines) + 2
     elseif val ~= nil and val > #cell.values then
-        row = row + (cell.total_display_rows or #cell.values) + 2
+        row = row + total_display_rows + 2
         jump = false
     elseif val ~= nil then
         local entry = cell.values[val]

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -148,6 +148,10 @@ end
 
 ---@param str string
 ---@return string[]
+-- Wraps by Unicode codepoint count (strchars), not display width or grapheme clusters;
+-- combining characters and ZWJ sequences may be split across rows.
+-- When expand_newlines=false, a \X escape pair that straddles a wrap boundary will
+-- lose its SpecialChar highlight on both halves (cosmetic only, display is unaffected).
 local function wrap_and_split(str)
     local lines = utils.DisplayLines(str)
     local max_w = config.max_line_width

--- a/lua/videre/utils.lua
+++ b/lua/videre/utils.lua
@@ -1,3 +1,5 @@
+local config = require("videre.config").config
+
 local M = {}
 
 ---@alias DataObjectTypeName
@@ -62,26 +64,6 @@ function M.StringWidth(val)
     return vim.str_utfindex(val, "utf-16")
 end
 
----@param str string
----@param width integer
----@param align RowAlignment
----@param space string
----@return integer, string, integer
-function M.PadLine(str, width, align, space)
-    local current_width = M.StringWidth(str)
-    local pad = width - current_width
-
-    if align == "left" then
-        return 0, str .. string.rep(space, pad), pad
-    elseif align == "right" then
-        return pad, string.rep(space, pad) .. str, 0
-    else
-        local left = math.floor(pad / 2)
-        local right = pad - left
-        return left, string.rep(space, left) .. str .. string.rep(space, right), right
-    end
-end
-
 ---@param val integer
 ---@return integer
 function M.NumberWidth(val)
@@ -108,26 +90,14 @@ function M.PadLine(str, width, align, space)
     end
 end
 
----Split a ValueAsString display string into visual rows.
----Walks str one character at a time via str_idx. On a backslash, the next
----character is consumed as a pair into current_line so that an escaped
----backslash (\\) never causes the character after it to be misread as a
----\\n/\\r/\\t marker. Completed rows are flushed into lines[]:
----  \\n  → flush current_line into lines, reset current_line
----  \\r\\n → treated as a single newline split (consume all 4 chars)
----  \\r  → keep literal \r in current_line (standalone CR, e.g. old Mac endings or regex patterns)
----  \\t  → append tab_width spaces to current_line
----  \\   → append "\\\\" to current_line (escaped backslash; next char skipped)
----  \\X  → append both chars unchanged to current_line
 ---@param str string
 ---@return string[]
 function M.DisplayLines(str)
-    local config = require("videre.config").config
     local tab_width = config.tab_width
     local expand_tabs = config.expand_tabs
     local expand_newlines = config.expand_newlines
 
-    local lines = {}
+    local split_lines = {}
     local current_line = {}
     local str_idx = 1
     while str_idx <= #str do
@@ -138,12 +108,12 @@ function M.DisplayLines(str)
                 current_line[#current_line + 1] = [[\\]]
                 str_idx = str_idx + 2
             elseif next == "n" and expand_newlines then
-                lines[#lines + 1] = table.concat(current_line)
+                split_lines[#split_lines + 1] = table.concat(current_line)
                 current_line = {}
                 str_idx = str_idx + 2
             elseif next == "r" and expand_newlines then
                 if str:sub(str_idx + 2, str_idx + 3) == [[\n]] then
-                    lines[#lines + 1] = table.concat(current_line)
+                    split_lines[#split_lines + 1] = table.concat(current_line)
                     current_line = {}
                     str_idx = str_idx + 4
                 else
@@ -162,7 +132,25 @@ function M.DisplayLines(str)
             str_idx = str_idx + 1
         end
     end
-    lines[#lines + 1] = table.concat(current_line)
+
+    split_lines[#split_lines + 1] = table.concat(current_line)
+
+    if config.max_line_width == 0 then
+        return split_lines
+    end
+
+    local lines = {}
+    for _, line in ipairs(split_lines) do
+        if M.StringWidth(line) > config.max_line_width then
+            while #line > 0 do
+                lines[#lines + 1] = vim.fn.strcharpart(line, 0, config.max_line_width)
+                line = vim.fn.strcharpart(line, config.max_line_width)
+            end
+        else
+            lines[#lines + 1] = line
+        end
+    end
+
     return lines
 end
 
@@ -179,8 +167,8 @@ function M.ValueAsString(tbl, val, width, align, space, is_key)
     if is_key then
         return M.PadLine(str, width, align, space)
     end
-    local tab_width = require("videre.config").config.tab_width
-    local first_line = M.DisplayLines(str, tab_width)[1]
+
+    local first_line = M.DisplayLines(str)[1]
     return M.PadLine(first_line, width, align, space)
 end
 

--- a/lua/videre/utils.lua
+++ b/lua/videre/utils.lua
@@ -62,6 +62,26 @@ function M.StringWidth(val)
     return vim.str_utfindex(val, "utf-16")
 end
 
+---@param str string
+---@param width integer
+---@param align RowAlignment
+---@param space string
+---@return integer, string, integer
+function M.PadLine(str, width, align, space)
+    local current_width = M.StringWidth(str)
+    local pad = width - current_width
+
+    if align == "left" then
+        return 0, str .. string.rep(space, pad), pad
+    elseif align == "right" then
+        return pad, string.rep(space, pad) .. str, 0
+    else
+        local left = math.floor(pad / 2)
+        local right = pad - left
+        return left, string.rep(space, left) .. str .. string.rep(space, right), right
+    end
+end
+
 ---@param val integer
 ---@return integer
 function M.NumberWidth(val)

--- a/test/test.json
+++ b/test/test.json
@@ -21,7 +21,7 @@
     "example": {
         "empty_array": [],
         "empty_table": {},
-        "test": "This is some\ntest data",
+        "test": "This is some\ntest data that is very long in length and needs to be split up into multiple parts",
         "nothing": null,
         "nested_table": {
             "string": "MY_STRING",


### PR DESCRIPTION
Adds a max_line_width config option (default 0 = disabled). When set, string values wider than max_line_width characters are wrapped across multiple display rows. Uses vim.fn.strcharpart for correct Unicode handling.

Wrapping is applied consistently in get_value_width, get_layer_min_height, and render_cell_at_width via a shared wrap_and_split helper.

<img width="1146" height="292" alt="image" src="https://github.com/user-attachments/assets/5c5b2073-28c4-4ce7-9963-05cd9e4d3edb" />

