### PR TITLE
feat: sticky header via scroll-independent overlay float

### DIFF
--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -7,9 +7,13 @@ local actions = require "videre.actions"
 
 local M = {}
 
+local header_ns = vim.api.nvim_create_namespace("videre_header")
+-- maps videre win -> { win = overlay_win, buf = overlay_buf }
+local header_floats = {}
+
 ---@param text string
----@return string winbar format string
-local function make_header_winbar(text)
+---@return { text: string, hl: string }[]
+local function make_header_chunks(text)
     local segments = {}
 
     local s, e = text:find("^%s*%+?Videre")
@@ -25,32 +29,105 @@ local function make_header_winbar(text)
 
     table.sort(segments, function(a, b) return a[1] < b[1] end)
 
-    local parts = {}
+    local chunks = {}
     local pos = 1
     for _, seg in ipairs(segments) do
         if pos < seg[1] then
-            parts[#parts + 1] = "%#StatusLine#" .. text:sub(pos, seg[1] - 1):gsub("%%", "%%%%")
+            chunks[#chunks + 1] = { text = text:sub(pos, seg[1] - 1), hl = "StatusLine" }
         end
-        parts[#parts + 1] = "%#" .. seg[3] .. "#" .. text:sub(seg[1], seg[2]):gsub("%%", "%%%%")
+        chunks[#chunks + 1] = { text = text:sub(seg[1], seg[2]), hl = seg[3] }
         pos = seg[2] + 1
     end
     if pos <= #text then
-        parts[#parts + 1] = "%#StatusLine#" .. text:sub(pos):gsub("%%", "%%%%")
+        chunks[#chunks + 1] = { text = text:sub(pos), hl = "StatusLine" }
     end
 
-    if #parts == 0 then
-        parts[#parts + 1] = "%#StatusLine#" .. text:gsub("%%", "%%%%")
+    if #chunks == 0 then
+        chunks[#chunks + 1] = { text = text, hl = "StatusLine" }
     end
 
-    return table.concat(parts) .. "%<"
+    return chunks
+end
+
+---@param overlay_buf integer
+---@param chunks { text: string, hl: string }[]
+local function render_chunks_to_buf(overlay_buf, chunks)
+    local text = ""
+    for _, c in ipairs(chunks) do text = text .. c.text end
+
+    vim.bo[overlay_buf].modifiable = true
+    vim.api.nvim_buf_set_lines(overlay_buf, 0, -1, false, { text })
+    vim.bo[overlay_buf].modifiable = false
+
+    vim.api.nvim_buf_clear_namespace(overlay_buf, header_ns, 0, -1)
+    local col = 0
+    for _, c in ipairs(chunks) do
+        local byte_len = #c.text
+        vim.api.nvim_buf_set_extmark(overlay_buf, header_ns, 0, col, {
+            end_col = col + byte_len,
+            hl_group = c.hl,
+        })
+        col = col + byte_len
+    end
+end
+
+---@param videre_win integer
+---@return integer overlay_win, integer overlay_buf
+local function create_header_float(videre_win)
+    local overlay_buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[overlay_buf].modifiable = false
+
+    local win_cfg = vim.api.nvim_win_get_config(videre_win)
+    local has_border = type(win_cfg.border) == "table" and #win_cfg.border > 0
+    local border_offset = has_border and 1 or 0
+    local win_width = vim.api.nvim_win_get_width(videre_win)
+    local overlay_width = win_width - border_offset * 2
+
+    local overlay_win = vim.api.nvim_open_win(overlay_buf, false, {
+        relative = "win",
+        win = videre_win,
+        row = border_offset,
+        col = border_offset,
+        width = overlay_width,
+        height = 1,
+        style = "minimal",
+        focusable = false,
+        zindex = (win_cfg.zindex or 10) + 1,
+    })
+
+    vim.wo[overlay_win].wrap = false
+    vim.wo[overlay_win].winhl = "Normal:StatusLine"
+
+    -- clean up overlay when the Videre window closes
+    vim.api.nvim_create_autocmd("WinClosed", {
+        pattern = tostring(videre_win),
+        once = true,
+        callback = function()
+            if vim.api.nvim_win_is_valid(overlay_win) then
+                vim.api.nvim_win_close(overlay_win, true)
+            end
+            header_floats[videre_win] = nil
+        end,
+    })
+
+    return overlay_win, overlay_buf
 end
 
 ---@param buf integer
 ---@param videre_table VidereTable
 local function update_header(buf, videre_table)
-    local winbar = make_header_winbar(statusline.GetStatuslineString(videre_table))
-    for _, win in ipairs(vim.fn.win_findbuf(buf)) do
-        vim.wo[win].winbar = winbar
+    local chunks = make_header_chunks(statusline.GetStatuslineString(videre_table))
+
+    for _, videre_win in ipairs(vim.fn.win_findbuf(buf)) do
+        local state = header_floats[videre_win]
+
+        if not state or not vim.api.nvim_win_is_valid(state.win) then
+            local overlay_win, overlay_buf = create_header_float(videre_win)
+            state = { win = overlay_win, buf = overlay_buf }
+            header_floats[videre_win] = state
+        end
+
+        render_chunks_to_buf(state.buf, chunks)
     end
 end
 

--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -52,6 +52,7 @@ end
 local function update_header(buf, videre_table)
     vim.api.nvim_buf_clear_namespace(buf, header_ns, 0, -1)
     local topline = vim.fn.line("w0") -- 1-indexed first visible line
+    if topline < 1 then return end
     local header_str = statusline.GetStatuslineString(videre_table)
     vim.api.nvim_buf_set_extmark(buf, header_ns, topline - 1, 0, {
         virt_lines_above = true,
@@ -138,6 +139,7 @@ local function on_mouse_move(buf, videre_table)
         vim.api.nvim_feedkeys("j", "n", false)
     end
 
+    update_header(buf, videre_table)
     highlighting.Clear(buf, true)
 
     if layer_n and cell_n then
@@ -158,8 +160,6 @@ local function on_mouse_move(buf, videre_table)
 
     actions.MakeCloseWindowMapping(buf, videre_table)
     actions.MakeOpenHelpMenuMapping(buf)
-
-    update_header(buf, videre_table)
 end
 
 ---@param buf integer

--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -7,11 +7,9 @@ local actions = require "videre.actions"
 
 local M = {}
 
-local header_ns = vim.api.nvim_create_namespace("videre_header")
-
 ---@param text string
----@return {[1]: string, [2]: string}[]
-local function make_header_chunks(text)
+---@return string winbar format string
+local function make_header_winbar(text)
     local segments = {}
 
     local s, e = text:find("^%s*%+?Videre")
@@ -27,37 +25,33 @@ local function make_header_chunks(text)
 
     table.sort(segments, function(a, b) return a[1] < b[1] end)
 
-    local chunks = {}
+    local parts = {}
     local pos = 1
     for _, seg in ipairs(segments) do
         if pos < seg[1] then
-            chunks[#chunks + 1] = { text:sub(pos, seg[1] - 1), "StatusLine" }
+            parts[#parts + 1] = "%#StatusLine#" .. text:sub(pos, seg[1] - 1):gsub("%%", "%%%%")
         end
-        chunks[#chunks + 1] = { text:sub(seg[1], seg[2]), seg[3] }
+        parts[#parts + 1] = "%#" .. seg[3] .. "#" .. text:sub(seg[1], seg[2]):gsub("%%", "%%%%")
         pos = seg[2] + 1
     end
     if pos <= #text then
-        chunks[#chunks + 1] = { text:sub(pos), "StatusLine" }
+        parts[#parts + 1] = "%#StatusLine#" .. text:sub(pos):gsub("%%", "%%%%")
     end
 
-    if #chunks == 0 then
-        chunks[#chunks + 1] = { text, "StatusLine" }
+    if #parts == 0 then
+        parts[#parts + 1] = "%#StatusLine#" .. text:gsub("%%", "%%%%")
     end
 
-    return chunks
+    return table.concat(parts)
 end
 
 ---@param buf integer
 ---@param videre_table VidereTable
 local function update_header(buf, videre_table)
-    vim.api.nvim_buf_clear_namespace(buf, header_ns, 0, -1)
-    local topline = vim.fn.line("w0") -- 1-indexed first visible line
-    if topline < 1 then return end
-    local header_str = statusline.GetStatuslineString(videre_table)
-    vim.api.nvim_buf_set_extmark(buf, header_ns, topline - 1, 0, {
-        virt_lines_above = true,
-        virt_lines = { make_header_chunks(header_str) },
-    })
+    local winbar = make_header_winbar(statusline.GetStatuslineString(videre_table))
+    for _, win in ipairs(vim.fn.win_findbuf(buf)) do
+        vim.wo[win].winbar = winbar
+    end
 end
 
 ---@param buf integer
@@ -202,18 +196,6 @@ function M.JoinTableToBuffer(buf, videre_table, clear_table)
         actions.ClearAllMappings(buf, videre_table)
         on_mouse_move(buf, videre_table)
     end)
-
-    vim.api.nvim_create_autocmd("WinScrolled", {
-        group = videre_table.grp,
-        callback = function(ev)
-            local win_id = tonumber(ev.match)
-            if vim.api.nvim_win_is_valid(win_id) and vim.api.nvim_win_get_buf(win_id) == buf then
-                vim.api.nvim_win_call(win_id, function()
-                    update_header(buf, videre_table)
-                end)
-            end
-        end,
-    })
 
     vim.api.nvim_buf_create_user_command(buf, "VidereCommit", function()
         local new_lines = videre_table.lang_spec.Encode(videre_table.data)

--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -42,7 +42,7 @@ local function make_header_winbar(text)
         parts[#parts + 1] = "%#StatusLine#" .. text:gsub("%%", "%%%%")
     end
 
-    return table.concat(parts)
+    return table.concat(parts) .. "%<"
 end
 
 ---@param buf integer

--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -7,6 +7,58 @@ local actions = require "videre.actions"
 
 local M = {}
 
+local header_ns = vim.api.nvim_create_namespace("videre_header")
+
+---@param text string
+---@return {[1]: string, [2]: string}[]
+local function make_header_chunks(text)
+    local segments = {}
+
+    local s, e = text:find("^%s*%+?Videre")
+    if s then segments[#segments + 1] = { s, e, "Keyword" } end
+
+    for bs, be in text:gmatch("()%[.-%]()") do
+        segments[#segments + 1] = { bs, be - 1, "Special" }
+    end
+
+    for ps, pe in text:gmatch("()%b()()") do
+        segments[#segments + 1] = { ps, pe - 1, "Identifier" }
+    end
+
+    table.sort(segments, function(a, b) return a[1] < b[1] end)
+
+    local chunks = {}
+    local pos = 1
+    for _, seg in ipairs(segments) do
+        if pos < seg[1] then
+            chunks[#chunks + 1] = { text:sub(pos, seg[1] - 1), "StatusLine" }
+        end
+        chunks[#chunks + 1] = { text:sub(seg[1], seg[2]), seg[3] }
+        pos = seg[2] + 1
+    end
+    if pos <= #text then
+        chunks[#chunks + 1] = { text:sub(pos), "StatusLine" }
+    end
+
+    if #chunks == 0 then
+        chunks[#chunks + 1] = { text, "StatusLine" }
+    end
+
+    return chunks
+end
+
+---@param buf integer
+---@param videre_table VidereTable
+local function update_header(buf, videre_table)
+    vim.api.nvim_buf_clear_namespace(buf, header_ns, 0, -1)
+    local topline = vim.fn.line("w0") -- 1-indexed first visible line
+    local header_str = statusline.GetStatuslineString(videre_table)
+    vim.api.nvim_buf_set_extmark(buf, header_ns, topline - 1, 0, {
+        virt_lines_above = true,
+        virt_lines = { make_header_chunks(header_str) },
+    })
+end
+
 ---@param buf integer
 ---@param fn fun()
 local function run_edit(buf, fn)
@@ -107,11 +159,7 @@ local function on_mouse_move(buf, videre_table)
     actions.MakeCloseWindowMapping(buf, videre_table)
     actions.MakeOpenHelpMenuMapping(buf)
 
-    run_edit(buf, function()
-        vim.api.nvim_buf_set_lines(buf, 0, 1, false, { statusline.GetStatuslineString(videre_table) })
-    end)
-
-    highlighting.HighlightBuffer(buf, videre_table, true)
+    update_header(buf, videre_table)
 end
 
 ---@param buf integer
@@ -134,7 +182,7 @@ function M.Redraw(buf, videre_table)
     highlighting.Clear(buf, false)
 
     run_edit(buf, function()
-        vim.api.nvim_buf_set_lines(buf, 1, -1, false, out_lines)
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, out_lines)
     end)
 
     highlighting.HighlightBuffer(buf, videre_table, false)
@@ -154,6 +202,18 @@ function M.JoinTableToBuffer(buf, videre_table, clear_table)
         actions.ClearAllMappings(buf, videre_table)
         on_mouse_move(buf, videre_table)
     end)
+
+    vim.api.nvim_create_autocmd("WinScrolled", {
+        group = videre_table.grp,
+        callback = function(ev)
+            local win_id = tonumber(ev.match)
+            if vim.api.nvim_win_is_valid(win_id) and vim.api.nvim_win_get_buf(win_id) == buf then
+                vim.api.nvim_win_call(win_id, function()
+                    update_header(buf, videre_table)
+                end)
+            end
+        end,
+    })
 
     vim.api.nvim_buf_create_user_command(buf, "VidereCommit", function()
         local new_lines = videre_table.lang_spec.Encode(videre_table.data)

--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -320,26 +320,6 @@ function M.JoinTableToBuffer(buf, videre_table, clear_table)
         end,
     })
 
-    -- close the overlay when the Videre buffer is replaced in a window (e.g. :buffer other)
-    -- without the window itself closing; BufWinEnter recreates it if the buffer returns
-    vim.api.nvim_create_autocmd("BufWinLeave", {
-        buffer = buf,
-        group = videre_table.grp,
-        callback = function()
-            local leaving_win = vim.api.nvim_get_current_win()
-            local state = header_floats[leaving_win]
-            if state then
-                if vim.api.nvim_win_is_valid(state.win) then
-                    vim.api.nvim_win_close(state.win, true)
-                end
-                if vim.api.nvim_buf_is_valid(state.buf) then
-                    vim.api.nvim_buf_delete(state.buf, { force = true })
-                end
-                header_floats[leaving_win] = nil
-            end
-        end,
-    })
-
     -- Clear group (including global resize autocmds) and close any lingering
     -- overlay floats when the buffer is deleted or wiped. The window may stay
     -- open with a different buffer, so the float must be explicitly removed.

--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -289,6 +289,18 @@ function M.JoinTableToBuffer(buf, videre_table, clear_table)
         on_mouse_move(buf, videre_table)
     end)
 
+    -- fires each time the Videre buffer enters any window; creates the header
+    -- for that window and refreshes cursor state (handles both initial open and
+    -- the case where the buffer is later shown in an additional split)
+    vim.api.nvim_create_autocmd("BufWinEnter", {
+        buffer = buf,
+        group = videre_table.grp,
+        callback = function()
+            actions.ClearAllMappings(buf, videre_table)
+            pcall(on_mouse_move, buf, videre_table)
+        end,
+    })
+
     -- not buffer-scoped: VimResized/WinResized fire globally; the Videre
     -- buffer may be visible but not current when the resize happens
     vim.api.nvim_create_autocmd({ "VimResized", "WinResized" }, {
@@ -299,7 +311,31 @@ function M.JoinTableToBuffer(buf, videre_table, clear_table)
                 if state and vim.api.nvim_win_is_valid(state.win) then
                     local win_width = vim.api.nvim_win_get_width(videre_win)
                     vim.api.nvim_win_set_config(state.win, { width = win_width })
+                    vim.api.nvim_win_call(videre_win, function()
+                        local chunks = make_header_chunks(statusline.GetStatuslineString(videre_table))
+                        render_chunks_to_buf(state.buf, chunks)
+                    end)
                 end
+            end
+        end,
+    })
+
+    -- close the overlay when the Videre buffer is replaced in a window (e.g. :buffer other)
+    -- without the window itself closing; BufWinEnter recreates it if the buffer returns
+    vim.api.nvim_create_autocmd("BufWinLeave", {
+        buffer = buf,
+        group = videre_table.grp,
+        callback = function()
+            local leaving_win = vim.api.nvim_get_current_win()
+            local state = header_floats[leaving_win]
+            if state then
+                if vim.api.nvim_win_is_valid(state.win) then
+                    vim.api.nvim_win_close(state.win, true)
+                end
+                if vim.api.nvim_buf_is_valid(state.buf) then
+                    vim.api.nvim_buf_delete(state.buf, { force = true })
+                end
+                header_floats[leaving_win] = nil
             end
         end,
     })

--- a/lua/videre/buffer.lua
+++ b/lua/videre/buffer.lua
@@ -10,6 +10,8 @@ local M = {}
 local header_ns = vim.api.nvim_create_namespace("videre_header")
 -- maps videre win -> { win = overlay_win, buf = overlay_buf }
 local header_floats = {}
+-- tracks the active augroup per Videre buf so navigation calls can clear the old one
+local active_grps = {}
 
 ---@param text string
 ---@return { text: string, hl: string }[]
@@ -32,11 +34,13 @@ local function make_header_chunks(text)
     local chunks = {}
     local pos = 1
     for _, seg in ipairs(segments) do
-        if pos < seg[1] then
-            chunks[#chunks + 1] = { text = text:sub(pos, seg[1] - 1), hl = "StatusLine" }
+        if seg[1] >= pos then
+            if pos < seg[1] then
+                chunks[#chunks + 1] = { text = text:sub(pos, seg[1] - 1), hl = "StatusLine" }
+            end
+            chunks[#chunks + 1] = { text = text:sub(seg[1], seg[2]), hl = seg[3] }
+            pos = seg[2] + 1
         end
-        chunks[#chunks + 1] = { text = text:sub(seg[1], seg[2]), hl = seg[3] }
-        pos = seg[2] + 1
     end
     if pos <= #text then
         chunks[#chunks + 1] = { text = text:sub(pos), hl = "StatusLine" }
@@ -81,7 +85,7 @@ local function create_header_float(videre_win)
     local has_border = type(win_cfg.border) == "table" and #win_cfg.border > 0
     local border_offset = has_border and 1 or 0
     local win_width = vim.api.nvim_win_get_width(videre_win)
-    local overlay_width = win_width - border_offset * 2
+    local overlay_width = win_width
 
     local overlay_win = vim.api.nvim_open_win(overlay_buf, false, {
         relative = "win",
@@ -105,6 +109,9 @@ local function create_header_float(videre_win)
         callback = function()
             if vim.api.nvim_win_is_valid(overlay_win) then
                 vim.api.nvim_win_close(overlay_win, true)
+            end
+            if vim.api.nvim_buf_is_valid(overlay_buf) then
+                vim.api.nvim_buf_delete(overlay_buf, { force = true })
             end
             header_floats[videre_win] = nil
         end,
@@ -210,7 +217,6 @@ local function on_mouse_move(buf, videre_table)
         vim.api.nvim_feedkeys("j", "n", false)
     end
 
-    update_header(buf, videre_table)
     highlighting.Clear(buf, true)
 
     if layer_n and cell_n then
@@ -231,6 +237,7 @@ local function on_mouse_move(buf, videre_table)
 
     actions.MakeCloseWindowMapping(buf, videre_table)
     actions.MakeOpenHelpMenuMapping(buf)
+    update_header(buf, videre_table)
 end
 
 ---@param buf integer
@@ -263,6 +270,14 @@ end
 ---@param videre_table VidereTable
 ---@param clear_table VidereTable|nil
 function M.JoinTableToBuffer(buf, videre_table, clear_table)
+    -- Clear the previous group for this buffer so global autocmds (resize)
+    -- from navigation paths that don't pass clear_table don't accumulate.
+    local prev_grp = active_grps[buf]
+    if prev_grp then
+        pcall(vim.api.nvim_clear_autocmds, { group = prev_grp })
+    end
+    active_grps[buf] = videre_table.grp
+
     if clear_table then
         vim.api.nvim_clear_autocmds({ group = clear_table.grp })
     end
@@ -273,6 +288,46 @@ function M.JoinTableToBuffer(buf, videre_table, clear_table)
         actions.ClearAllMappings(buf, videre_table)
         on_mouse_move(buf, videre_table)
     end)
+
+    -- not buffer-scoped: VimResized/WinResized fire globally; the Videre
+    -- buffer may be visible but not current when the resize happens
+    vim.api.nvim_create_autocmd({ "VimResized", "WinResized" }, {
+        group = videre_table.grp,
+        callback = function()
+            for _, videre_win in ipairs(vim.fn.win_findbuf(buf)) do
+                local state = header_floats[videre_win]
+                if state and vim.api.nvim_win_is_valid(state.win) then
+                    local win_width = vim.api.nvim_win_get_width(videre_win)
+                    vim.api.nvim_win_set_config(state.win, { width = win_width })
+                end
+            end
+        end,
+    })
+
+    -- Clear group (including global resize autocmds) and close any lingering
+    -- overlay floats when the buffer is deleted or wiped. The window may stay
+    -- open with a different buffer, so the float must be explicitly removed.
+    vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+        buffer = buf,
+        group = videre_table.grp,
+        once = true,
+        callback = function()
+            for _, videre_win in ipairs(vim.fn.win_findbuf(buf)) do
+                local state = header_floats[videre_win]
+                if state then
+                    if vim.api.nvim_win_is_valid(state.win) then
+                        vim.api.nvim_win_close(state.win, true)
+                    end
+                    if vim.api.nvim_buf_is_valid(state.buf) then
+                        vim.api.nvim_buf_delete(state.buf, { force = true })
+                    end
+                    header_floats[videre_win] = nil
+                end
+            end
+            vim.api.nvim_clear_autocmds({ group = videre_table.grp })
+            active_grps[buf] = nil
+        end,
+    })
 
     vim.api.nvim_buf_create_user_command(buf, "VidereCommit", function()
         local new_lines = videre_table.lang_spec.Encode(videre_table.data)

--- a/lua/videre/highlighting.lua
+++ b/lua/videre/highlighting.lua
@@ -34,12 +34,12 @@ function M.HighlightFocusedCell(buf, cell, left)
         return convert_col_to_bytes(pos, buf)
     end
 
-    vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line, left },
-        B { cell.top_render_line, left + cell.render_width })
+    vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line - 1, left },
+        B { cell.top_render_line - 1, left + cell.render_width })
 
     local total_rows = cell.total_display_rows or #cell.values
     for i, entry in ipairs(cell.values) do
-        local first_line = cell.top_render_line + (entry.row_offset or i)
+        local first_line = cell.top_render_line - 1 + (entry.row_offset or i)
         local span = entry_row_span(cell, i, total_rows)
 
         for s = 0, span - 1 do
@@ -55,13 +55,13 @@ function M.HighlightFocusedCell(buf, cell, left)
         end
     end
 
-    vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line + total_rows + 1, left },
-        B { cell.top_render_line + total_rows + 1, left + cell.render_width })
+    vim.hl.range(buf, ns_s, videre_special, B { cell.top_render_line - 1 + total_rows, left },
+        B { cell.top_render_line - 1 + total_rows, left + cell.render_width })
 
     if #cell.hidden_values > 0 then
         vim.hl.range(buf, ns_s, videre_special,
-            B { cell.top_render_line + total_rows + 2, left },
-            B { cell.top_render_line + total_rows + 2, left + cell.render_width })
+            B { cell.top_render_line + total_rows, left },
+            B { cell.top_render_line + total_rows, left + cell.render_width })
     end
 
     local mouse_row = vim.api.nvim_win_get_cursor(0)[1] - 1
@@ -95,24 +95,6 @@ local function highlight_escapes(bufnr, line, text, string_start)
 end
 
 ---@param buf integer
-local function highlight_statusline(buf)
-    local text = vim.api.nvim_buf_get_lines(buf, 0, 1, true)[1]
-
-    local s, e = text:find("^%s*(%+?Videre)")
-    if s then
-        vim.hl.range(buf, ns_s, "Keyword", { 0, s - 1 }, { 0, e })
-    end
-
-    for bs, be in text:gmatch("()%[.-%]()") do
-        vim.hl.range(buf, ns_s, "Special", { 0, bs - 1 }, { 0, be })
-    end
-
-    for ps, pe in text:gmatch("()%b()()") do
-        vim.hl.range(buf, ns_s, "Identifier", { 0, ps - 1 }, { 0, pe })
-    end
-end
-
----@param buf integer
 ---@param tbl VidereTable
 ---@param cell VidereCell
 ---@param left integer
@@ -126,7 +108,7 @@ local function highlight_cell_values(buf, tbl, cell, left)
 
     local total_rows = cell.total_display_rows or #cell.values
     for i, entry in pairs(cell.values) do
-        local line = cell.top_render_line + (entry.row_offset or i)
+        local line = cell.top_render_line - 1 + (entry.row_offset or i)
         local span = entry_row_span(cell, i, total_rows)
 
         vim.hl.range(buf, ns, "Comment",
@@ -203,7 +185,6 @@ function M.HighlightBuffer(buf, tbl, statusline_only)
         end
     end
 
-    highlight_statusline(buf)
 end
 
 ---@param buf integer

--- a/lua/videre/statusline.lua
+++ b/lua/videre/statusline.lua
@@ -6,8 +6,6 @@ local M = {}
 ---@param tbl VidereTable
 ---@return string
 function M.GetStatuslineString(tbl)
-    local pad = string.rep(" ", vim.fn.winsaveview().leftcol)
-
     local result = (tbl.is_saved and "" or "+") .. "Videre [" .. config.keymaps.help .. " "
 
     result = result .. table.concat(tbl.available_maps, " ") .. "] "
@@ -45,7 +43,7 @@ function M.GetStatuslineString(tbl)
         result = result .. "—"
     end
 
-    return pad .. result .. table.concat(change_indicator, "—")
+    return result .. table.concat(change_indicator, "—")
 end
 
 return M

--- a/lua/videre/table.lua
+++ b/lua/videre/table.lua
@@ -587,7 +587,9 @@ function M.JumpToCellAndValue(tbl, layer_num, cell_num, val)
     local layer = tbl.layers[layer_num]
     local col = layer.left_render_col
     local cell = layer.cells[cell_num]
-    local row = cell.top_render_line
+    -- top_render_line is 1-indexed within the layer; buffer has no header line offset,
+    -- so subtract 1 to get the 1-indexed buffer line of the cell's top border.
+    local row = cell.top_render_line - 1
 
     local total_display_rows = cell.total_display_rows or #cell.values
     local jump = true

--- a/lua/videre/utils.lua
+++ b/lua/videre/utils.lua
@@ -188,7 +188,7 @@ end
 ---@param tbl VidereTable
 ---@return integer|nil, integer|nil, integer|nil|"expand"
 function M.GetHoveredCell(tbl)
-    local mrow, mcol = M.GetMousePos(1)
+    local mrow, mcol = M.GetMousePos(0)
 
     local layer_in, cell_in;
     for i, layer in ipairs(tbl.layers) do


### PR DESCRIPTION
## Summary

Adds a sticky header that displays the statusline string (navigation path, keymaps, history indicators) above the table in a floating window that doesn't scroll with the content.

- **Overlay float**: replaces the original first-line header (removed from buffer content) with a `relative="win"` float positioned at the top of the Videre window. The float is scroll-independent, stays pinned while the table scrolls.
- **Highlighting**: moved from `highlight_statusline` (buffer-based) to chunked extmarks on the overlay buffer, with syntax coloring for the Videre keyword, key shortcuts, and path segments.
- **Multi-line cell highlighting**: fixed `top_render_line` offset arithmetic throughout `highlighting.lua` and `table.lua` after removing the header line from buffer row 0.
- **GetHoveredCell**: corrected `GetMousePos` offset from 1 to 0 to match the new buffer layout.

## Lifecycle

- `BufWinEnter` (non-once): creates/refreshes the header for each window the buffer enters; handles initial open and additional splits.
- `BufWinLeave`: closes the overlay when the Videre buffer is replaced in a window (e.g. `:buffer other`) without that window closing.
- `WinClosed`: closes the overlay when the Videre window closes.
- `BufDelete`/`BufWipeout`: closes all overlays and clears autocmds.
- `VimResized`/`WinResized`: updates float width and re-renders header content under `nvim_win_call` (needed because `GetStatuslineString` calls `nvim_win_get_width(0)`).
- `active_grps` table prevents autocmd accumulation across navigation calls that don't pass `clear_table`.

## Test plan

- [ ] Open a JSON file; confirm sticky header appears above the table
- [ ] Scroll the table; confirm header stays pinned
- [ ] Navigate into a nested object; confirm header path updates
- [ ] Resize the window; confirm header width and content update correctly
- [ ] Split window and show same buffer in two panes; confirm both get headers
- [ ] `:buffer other` in the Videre window; confirm header disappears
- [ ] Return Videre buffer to that window; confirm header reappears
- [ ] Close the Videre window; confirm no lingering float windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)